### PR TITLE
application start up code changes

### DIFF
--- a/jhotdraw-samples/jhotdraw-samples-misc/src/main/java/org/jhotdraw/samples/svg/Main.java
+++ b/jhotdraw-samples/jhotdraw-samples-misc/src/main/java/org/jhotdraw/samples/svg/Main.java
@@ -28,11 +28,8 @@ public class Main {
     ResourceBundleUtil.setVerbose(true);
     Application app;
     String os = System.getProperty("os.name").toLowerCase();
-    if (os.startsWith("mac")) {
+    if (os.contains("mac")) {
       app = new OSXApplication();
-    } else if (os.startsWith("win")) {
-      //  app = new MDIApplication();
-      app = new SDIApplication();
     } else {
       app = new SDIApplication();
     }


### PR DESCRIPTION
I changed the function startsWith() to contain() , in case the os name does not start with exactly the key words "win" or "mac" .

I also removed the if "win" condition because the windows application will launch either way if the os name does not match the conditions